### PR TITLE
Searching for Pets for an Application - US4

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -19,6 +19,9 @@ class ApplicationsController < ApplicationController
 
   def show
     @app = Application.find(id)
+    if params[:q]
+      @search_results = Pet.where("name ILIKE ?", "%#{params[:q]}%").pluck(:name)
+    end
   end
 
   private

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -3,5 +3,19 @@
 <p>Name: <%= @app.name %></p>
 <p>Address: <%= @app.full_address %></p>
 <p>Description: <%= @app.description %></p>
-<p>Pets: <%= @app.pet_names %></p>
+<p>Pets: <%= @app.pet_names.join(" | ") %></p>
 <p>Application Status: <%= @app.status %></p>
+
+<% if @app.status == "In Progress" %>
+  <hr>
+  <h3>Add a Pet</h3>
+  <%= form_with url: "/applications/#{@app.id}", method: :get, turbo: false do |form| %>
+    <%= form.label :q, "Name:" %>
+    <%= form.search_field :q %>
+
+    <%= form.submit "Search" %>
+  <% end %>
+  <% if @search_results %>
+      <p>Search Results: <%= @search_results.join(" | ") %></p>
+  <% end %>
+<% end %>

--- a/spec/features/applications/new_spec.rb
+++ b/spec/features/applications/new_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "New Application Form", type: :feature do
         fill_in "Status", with: "In Progress"
         click_button "Submit"
 
-        expect(current_path).to eq("/applications/#{application.id}")
+        expect(current_path).to eq("/applications/#{@app2.id + 1}")
 
         expect(page).to have_content("Roman")
         expect(page).to have_content("444 Berry Way")

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -2,10 +2,18 @@ require "rails_helper"
 
 RSpec.describe "applications show page" do
   before(:each) do
-    @app1 = Application.create!(name: "Charles", address: "123 S Monroe", city: "Denver", state: "CO", zip: "80102",
-      description: "Good home for good boy", status: "In Progress")
-    @app2 = Application.create!(name: "TP", address: "1080 Pronghorn", city: "Del Norte", state: "CO", zip: "81132",
-      description: "Good home for good boy", status: "In Progress")
+    @app1 = Application.create!(
+      name: "Charles", address: "123 S Monroe", city: "Denver", state: "CO", zip: "80102",
+      description: "Good home for good boy", status: "In Progress"
+    )
+    @app2 = Application.create!(
+      name: "TP", address: "1080 Pronghorn", city: "Del Norte", state: "CO", zip: "81132",
+      description: "Good home for good boy", status: "In Progress"
+    )
+    @app_accepted = Application.create!(
+      name: "Robby", address: "1080 Pronghorn", city: "Del Norte", state: "CO", zip: "81132",
+      description: "Good home for good boy", status: "Accepted"
+    )
     @s1 = Shelter.create!(foster_program: true, name: "Paw Patrol", city: "Denver", rank: 2)
     @p1 = Pet.create!(name: "Buster", adoptable: true, age: 7, breed: "mut", shelter_id: @s1.id)
     @p2 = Pet.create!(name: "Kyo", adoptable: false, age: 1, breed: "calico", shelter_id: @s1.id)
@@ -14,6 +22,7 @@ RSpec.describe "applications show page" do
   end
 
   it "shows the attributes of the application" do
+    # US 1
     # As a visitor
     # When I visit an applications show page
     # Then I can see the following:
@@ -30,5 +39,36 @@ RSpec.describe "applications show page" do
     expect(page).to have_content @app1.description
     expect(page).to have_content @app1.pet_names
     expect(page).to have_content @app1.status
+  end
+
+  describe "unsubmitted applications" do
+    # US 4
+    # As a visitor
+    # When I visit an application's show page
+    # And that application has not been submitted,
+    # Then I see a section on the page to "Add a Pet to this Application"
+    # In that section I see an input where I can search for Pets by name
+    # When I fill in this field with a Pet's name
+    # And I click submit,
+    # Then I am taken back to the application show page
+    # And under the search bar I see any Pet whose name matches my search
+    it "shows Add a Pet section" do
+      visit "/applications/#{@app2.id}"
+
+      expect(page).to have_content "Add a Pet"
+
+      visit "/applications/#{@app_accepted.id}"
+
+      expect(page).to_not have_content "Add a Pet"
+    end
+
+    it "shows a search bar" do  # US 4.1
+      visit "/applications/#{@app2.id}"
+
+      fill_in :name, with: "Buster"
+      click_button "Search"
+
+      expect(page).to have_content "Search Results: Buster"
+    end
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "applications show page" do
     expect(page).to have_content @app1.name
     expect(page).to have_content @app1.full_address
     expect(page).to have_content @app1.description
-    expect(page).to have_content @app1.pet_names
+    expect(page).to have_content @app1.pet_names.join(" | ")
     expect(page).to have_content @app1.status
   end
 
@@ -65,7 +65,7 @@ RSpec.describe "applications show page" do
     it "shows a search bar" do  # US 4.1
       visit "/applications/#{@app2.id}"
 
-      fill_in :name, with: "Buster"
+      fill_in :q, with: "Buster"
       click_button "Search"
 
       expect(page).to have_content "Search Results: Buster"


### PR DESCRIPTION
As a visitor
When I visit an application's show page
And that application has not been submitted,
Then I see a section on the page to "Add a Pet to this Application"
In that section I see an input where I can search for Pets by name
When I fill in this field with a Pet's name
And I click submit,
Then I am taken back to the application show page
And under the search bar I see any Pet whose name matches my search
