### PR TITLE
feature/ads 7 add a pet to an application

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -20,8 +20,15 @@ class ApplicationsController < ApplicationController
   def show
     @app = Application.find(id)
     if params[:q]
-      @search_results = Pet.where("name ILIKE ?", "%#{params[:q]}%").pluck(:name)
+      @search_results = Pet.where("name ILIKE ?", "%#{params[:q]}%")
     end
+  end
+
+  def update
+    # use silent create here so if unique combination isn't entered, then just reloads page
+    PetApplication.create(application_id: params[:id], pet_id: params[:adopt])
+
+    redirect_to "/applications/#{params[:id]}"
   end
 
   private

--- a/app/models/pet_application.rb
+++ b/app/models/pet_application.rb
@@ -1,4 +1,5 @@
 class PetApplication < ApplicationRecord
   belongs_to :pet
   belongs_to :application
+  validates :pet_id, uniqueness: {scope: :application_id, message: "and Application combination must be unique"}
 end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -16,6 +16,18 @@
     <%= form.submit "Search" %>
   <% end %>
   <% if @search_results %>
-      <p>Search Results: <%= @search_results.join(" | ") %></p>
+      <p>Search Results:</p>
+    <% @search_results.each do |pet| %>
+      <section id="pet-<%= pet.id %>">
+        <div style="display: inline-block;">
+          <%= pet.name %>
+        </div>
+        <div style="display: inline-block;">
+          <%= form_for "Adopt", url: "/applications/#{@app.id}?adopt=#{pet.id}", method: :patch, data: {turbo: false} do |form| %>
+            <%= form.submit "Adopt" %>
+          <% end %>
+        </div>
+      </section>
+    <% end %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
+  resources :applications do
+    member do
+      patch :add
+    end
+  end
+
   get "/", to: "application#welcome"
 
   get "/shelters", to: "shelters#index"
@@ -40,4 +46,5 @@ Rails.application.routes.draw do
   get "/applications/new", to: "applications#new"
   post "/applications", to: "applications#create"
   get "/applications/:id", to: "applications#show"
+  patch "/applications/:id", to: "applications#update"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,4 @@
 Rails.application.routes.draw do
-  resources :applications do
-    member do
-      patch :add
-    end
-  end
-
   get "/", to: "application#welcome"
 
   get "/shelters", to: "shelters#index"
@@ -43,8 +37,8 @@ Rails.application.routes.draw do
   get "/veterinary_offices/:veterinary_office_id/veterinarians/new", to: "veterinarians#new"
   post "/veterinary_offices/:veterinary_office_id/veterinarians", to: "veterinarians#create"
 
-  get "/applications/new", to: "applications#new"
   post "/applications", to: "applications#create"
+  get "/applications/new", to: "applications#new"
   get "/applications/:id", to: "applications#show"
   patch "/applications/:id", to: "applications#update"
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -68,9 +68,10 @@ RSpec.describe "applications show page" do
       fill_in :q, with: "Buster"
       click_button "Search"
 
-      expect(page).to have_content "Search Results: Buster"
+      expect(page).to have_content "Search Results:\nBuster"
     end
 
+    # US 5
     # As a visitor
     # When I visit an application's show page
     # And I search for a Pet by name
@@ -79,8 +80,17 @@ RSpec.describe "applications show page" do
     # When I click one of these buttons
     # Then I am taken back to the application show page
     # And I see the Pet I want to adopt listed on this application
-    it "shows a button to adopt pet after search match" do
-      
+    it "shows a button inline with pet to adopt pet after search match" do
+      visit "/applications/#{@app2.id}"
+
+      fill_in :q, with: "Buster"
+      click_button "Search"
+
+      within("#pet-#{@p1.id}") do
+        click_button "Adopt"
+      end
+
+      expect(page).to have_content "Pets: Buster"
     end
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -70,5 +70,17 @@ RSpec.describe "applications show page" do
 
       expect(page).to have_content "Search Results: Buster"
     end
+
+    # As a visitor
+    # When I visit an application's show page
+    # And I search for a Pet by name
+    # And I see the names Pets that match my search
+    # Then next to each Pet's name I see a button to "Adopt this Pet"
+    # When I click one of these buttons
+    # Then I am taken back to the application show page
+    # And I see the Pet I want to adopt listed on this application
+    it "shows a button to adopt pet after search match" do
+      
+    end
   end
 end


### PR DESCRIPTION
As a visitor
When I visit an application's show page
And I search for a Pet by name
And I see the names Pets that match my search
Then next to each Pet's name I see a button to "Adopt this Pet"
When I click one of these buttons
Then I am taken back to the application show page
And I see the Pet I want to adopt listed on this application
