### PR TITLE
feature/ads 10 case insensitive matches for pet names us8 us9

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -20,7 +20,7 @@ class ApplicationsController < ApplicationController
   def show
     @app = Application.find(id)
     if params[:q]
-      @search_results = Pet.where("name ILIKE ?", "%#{params[:q]}%")
+      @search_results = Pet.search(params[:q])
     end
   end
 

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe Pet, type: :model do
         # And I search for Pets by name
         # Then my search is case insensitive
         # For example, if I search for "fluff", my search would match pets with names "Fluffy", "FLUFF", and "Mr. FlUfF"
-        expect(Pet.search("pirate")).to eq [@pet_1]
+        expect(Pet.search("pirate")).to eq([@pet_1])
       end
 
       it "returns all animals on empty query" do
-        expect(Pet.search("")).to eq [@pet_1, @pet_2, @pet_3]
+        expect(Pet.search("")).to eq([@pet_1, @pet_2, @pet_3])
       end
     end
 

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -21,7 +21,25 @@ RSpec.describe Pet, type: :model do
   describe "class methods" do
     describe "#search" do
       it "returns partial matches" do
+        # As a visitor US8
+        # When I visit an application show page
+        # And I search for Pets by name
+        # Then I see any pet whose name PARTIALLY matches my search
+        # For example, if I search for "fluff", my search would match pets with names "fluffy", "fluff", and "mr. fluff"
         expect(Pet.search("Claw")).to eq([@pet_2])
+      end
+
+      it "returns case insensitive matches" do
+        # As a visitor US9
+        # When I visit an application show page
+        # And I search for Pets by name
+        # Then my search is case insensitive
+        # For example, if I search for "fluff", my search would match pets with names "Fluffy", "FLUFF", and "Mr. FlUfF"
+        expect(Pet.search("pirate")).to eq [@pet_1]
+      end
+
+      it "returns all animals on empty query" do
+        expect(Pet.search("")).to eq [@pet_1, @pet_2, @pet_3]
       end
     end
 


### PR DESCRIPTION
As a visitor
When I visit an application show page
And I search for Pets by name
Then I see any pet whose name PARTIALLY matches my search
For example, if I search for "fluff", my search would match pets with names "fluffy", "fluff", and "mr. fluff"

As a visitor
When I visit an application show page
And I search for Pets by name
Then my search is case insensitive
For example, if I search for "fluff", my search would match pets with names "Fluffy", "FLUFF", and "Mr. FlUfF"
